### PR TITLE
Wrap package for CppUTest 4.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -10,7 +10,7 @@ cpputest_dep = declare_dependency(
     version : meson.project_version(),
     include_directories : cpputest_dirs)
 
-if get_option('extinctions') == true
+if get_option('extinctions')
     cpputest_dep = declare_dependency(
         link_with : cpputest_ext_lib,
         version : meson.project_version(),

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,18 @@
+  project('cpputest', 'cpp',
+    version : '4.0',
+    license : 'BSD-3')
+
+cpputest_dirs = include_directories('include')
+subdir('src')
+
+cpputest_dep = declare_dependency(
+    link_with : cpputest_lib,
+    version : meson.project_version(),
+    include_directories : cpputest_dirs)
+
+if get_option('extinctions') == true
+    cpputest_dep = declare_dependency(
+        link_with : cpputest_ext_lib,
+        version : meson.project_version(),
+        include_directories : cpputest_dirs)
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,3 @@
+option('extinctions',
+    type : 'boolean',
+    value : 'false')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,5 @@
 option('extinctions',
     type : 'boolean',
-    value : 'false')
+    value : 'true',
+    description : 'Use the CppUTest extension library'
+)

--- a/src/CppUTest/meson.build
+++ b/src/CppUTest/meson.build
@@ -1,0 +1,25 @@
+cpputest_src = files(
+    'CommandLineArguments.cpp',
+    'CommandLineTestRunner.cpp',
+    'JUnitTestOutput.cpp',
+    'MemoryLeakDetector.cpp',
+    'MemoryLeakWarningPlugin.cpp',
+    'SimpleMutex.cpp',
+    'SimpleString.cpp',
+    'SimpleStringInternalCache.cpp',
+    'TeamCityTestOutput.cpp',
+    'TestFailure.cpp',
+    'TestFilter.cpp',
+    'TestHarness_c.cpp',
+    'TestMemoryAllocator.cpp',
+    'TestOutput.cpp',
+    'TestPlugin.cpp',
+    'TestRegistry.cpp',
+    'TestResult.cpp',
+    'TestTestingFixture.cpp',
+    'Utest.cpp'
+)
+
+cpputest_lib = static_library('CppUTest',
+    cpputest_src,
+    include_directories : cpputest_dirs)

--- a/src/CppUTestExt/meson.build
+++ b/src/CppUTestExt/meson.build
@@ -1,0 +1,21 @@
+cpputest_ext_src = files(
+    'CodeMemoryReportFormatter.cpp',
+    'GTest.cpp',
+    'IEEE754ExceptionsPlugin.cpp',
+    'MemoryReportAllocator.cpp',
+    'MemoryReporterPlugin.cpp',
+    'MemoryReportFormatter.cpp',
+    'MockActualCall.cpp',
+    'MockExpectedCall.cpp',
+    'MockExpectedCallsList.cpp',
+    'MockFailure.cpp',
+    'MockNamedValue.cpp',
+    'MockSupport_c.cpp',
+    'MockSupport.cpp',
+    'MockSupportPlugin.cpp',
+    'OrderedTest.cpp'
+)
+
+cpputest_ext_lib = static_library('CppUTestExt',
+    cpputest_ext_src,
+    include_directories : cpputest_dirs)

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,4 +1,4 @@
-if get_option('extinctions') == true
+if get_option('extinctions')
     cpputest_ext_src = []
     subdir('CppUTestExt')
 endif

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,7 @@
+if get_option('extinctions') == true
+    cpputest_ext_src = []
+    subdir('CppUTestExt')
+endif
+
+cpputest_src = []
+subdir('CppUTest')

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,5 +1,5 @@
 [wrap-file]
-directory = cpputest
+directory = cpputest-4.0
 source_url = https://github.com/cpputest/cpputest/archive/v4.0.zip
 source_filename = cpputest-4.0.zip
 source_hash = b81d0c34f300bc1ed39e152fb92e178555a784e294e1f1cefe074326c2588339

--- a/upstream.wrap
+++ b/upstream.wrap
@@ -1,0 +1,6 @@
+[wrap-file]
+directory = cpputest
+source_url = https://github.com/cpputest/cpputest/archive/v4.0.zip
+source_filename = cpputest-4.0.zip
+source_hash = b81d0c34f300bc1ed39e152fb92e178555a784e294e1f1cefe074326c2588339
+


### PR DESCRIPTION
Wrap package for CppUTest. There are two dependencies declared in the package one for the test framework and the other for the framework extensions.